### PR TITLE
Export Canvas.ImageData constructor

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -11,5 +11,9 @@ Canvas.Image = function () {
   return img
 }
 
-
-
+Canvas.ImageData = function () {
+  return new (Function.prototype.bind
+              .apply(ImageData, [null]
+                     .concat(Array.prototype.slice
+                             .call(arguments))))
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/dominictarr/canvas-browserify.git"
   },
   "optionalDependencies": {
-    "canvas": "^1.2.7"
+    "canvas": "^1.3.2"
   },
   "scripts": {
     "test": "set -e; for t in test/*.js; do node $t; done"


### PR DESCRIPTION
`node-canvas` defines its own ImageData constructor.  Previously it was not exposed by `module.exports`, but it is since `1.3.0`.  I have found this addition helpful, maybe others will too.
